### PR TITLE
Deprecate Processes method before removal in a future version

### DIFF
--- a/AlastairLundy.Extensions.System/Processes/IsProcessRunningExtensions.cs
+++ b/AlastairLundy.Extensions.System/Processes/IsProcessRunningExtensions.cs
@@ -22,6 +22,7 @@
        SOFTWARE.
    */
 
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -35,6 +36,7 @@ namespace AlastairLundy.Extensions.System.Processes
         /// </summary>
         /// <param name="process">The process to be checked.</param>
         /// <returns>True if the specified process is running; returns false otherwise.</returns>
+        [Obsolete("This method is deprecated and will be removed in a future version.")]
         public static bool IsRunning(this Process process)
         {
             if (process.HasStarted())

--- a/AlastairLundy.Extensions.System/Processes/ProcessHasStartedExtensions.cs
+++ b/AlastairLundy.Extensions.System/Processes/ProcessHasStartedExtensions.cs
@@ -35,6 +35,7 @@ public static class ProcessHasStartedExtensions
     /// </summary>
     /// <param name="process">The process to be checked.</param>
     /// <returns>True if it has started; false otherwise.</returns>
+    [Obsolete("This method is deprecated and will be removed in a future version.")]
     public static bool HasStarted(this Process process)
     {
         try

--- a/AlastairLundy.Extensions.System/Processes/SanitizeProcessNamesExtensions.cs
+++ b/AlastairLundy.Extensions.System/Processes/SanitizeProcessNamesExtensions.cs
@@ -23,6 +23,7 @@
    */
 
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -38,6 +39,7 @@ namespace AlastairLundy.Extensions.System.Processes
         /// <param name="process">The process to sanitize the name of.</param>
         /// <param name="excludeFileExtension">Whether to remove the file extension from the Process when sanitizing the process name.</param>
         /// <returns>the sanitized process names.</returns>
+        [Obsolete("This method is deprecated and will be removed in a future version.")]
         public static string SanitizeProcessName(this Process process, bool excludeFileExtension = true)
         {
 #if NET8_0_OR_GREATER
@@ -53,6 +55,7 @@ namespace AlastairLundy.Extensions.System.Processes
         /// <param name="processNames">The list of Processes to sanitize the names of.</param>
         /// <param name="excludeFileExtensions">Whether to remove the file extension from the Process when sanitizing the process name.</param>
         /// <returns>the sanitized process names.</returns>
+        [Obsolete("This method is deprecated and will be removed in a future version.")]
         public static IEnumerable<string> SanitizeProcessNames(this IEnumerable<Process> processNames, bool excludeFileExtensions = true)
         {
             List<string> output;


### PR DESCRIPTION
Process related code is being moved to the separate ProcessExtensions package. 

Before the code can be removed from SystemExtensions in a future major version it must first be deprecated.

This PR deprecates the Process related extension methods in SystemExtensions.